### PR TITLE
Update GITHUB_TOKEN usage in hourly.yml

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: run x.cs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: dotnet run x.cs
 
       - name: Commit and push if changed


### PR DESCRIPTION
You don't have to maintain a personal GitHub token as a secret if you just use the built in one. You're already granting all the required permissions in the yaml. `${{ github.token }}` is the more-modern way of accomplishing this goal.

You also may not need to customize the author when committing.